### PR TITLE
Change the build directory to docs/api/v3 to make it easier to put it…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 namespace :assets do
   task :precompile do
-    sh "middleman build"
+    sh "middleman build --build-dir='docs/api/v3'"
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 namespace :assets do
   task :precompile do
-    sh "middleman build --build-dir='docs/api/v3'"
+    sh "middleman build --build-dir='build/docs/api/v3'"
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -13,7 +13,7 @@ end
 
 # Attempt to serve static HTML files
 use Rack::TryStatic,
-    :root => "build",
+    :root => "docs/api/v3",
     :urls => %w[/],
     :try => ['.html', 'index.html', '/index.html']
 

--- a/config.ru
+++ b/config.ru
@@ -13,7 +13,7 @@ end
 
 # Attempt to serve static HTML files
 use Rack::TryStatic,
-    :root => "docs/api/v3",
+    :root => "build",
     :urls => %w[/],
     :try => ['.html', 'index.html', '/index.html']
 


### PR DESCRIPTION
From @billhorsman 

> Is it possible for you to put your API docs at `https://api-docs-tito-production.herokuapp.com/docs/api/v3`? The reason is your docs link to `stylesheets/screen.css` (for example) which the browser interprets as `https://ti.to/stylesheets/screen.css` which doesn’t point at your app.