### PR TITLE
Add a 404 page so that when requests can't be fulfilled we respond with a 404 instead of a 500.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -25,6 +25,6 @@ run lambda { |env|
       "Content-Type" => "text/html",
       "Cache-Control" => "public, max-age=60"
     },
-    File.open("build/404/index.html", File::RDONLY)
+    File.open("build/docs/api/v3/404.html", File::RDONLY)
   ]
 }

--- a/source/404.html.erb
+++ b/source/404.html.erb
@@ -1,0 +1,4 @@
+
+<h1>
+  Page not found
+</h1>


### PR DESCRIPTION
### Story

As an API developer, if I end up on a page that doesn't exist I expect to be served a 404 page rather than a 500.