### PR TITLE
Ensure the nav is scrollable when there is a lot of endpoints and the viewport is small.

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -60,6 +60,8 @@ html, body {
   font-size: 13px;
   font-weight: bold;
 
+  overflow-y: auto;
+
   // language selector for mobile devices
   .lang-selector {
     display: none;


### PR DESCRIPTION
### Story

As an API developer, I want the nav to be scrollable so that if I have a small browser viewport that I can still scroll to all of our lovely docs.

### Details

There is no overflow-y set on the nav
