### PR TITLE
Make the links in the nav completely unique so that clicking the Attributes link in the nav for a section takes you to the correct set of attributes.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,5 @@
 # Unique header generation
-require './lib/unique_head.rb'
+require './lib/nesting_unique_head.rb'
 
 # Markdown
 set :markdown_engine, :redcarpet
@@ -12,7 +12,7 @@ set :markdown,
     tables: true,
     with_toc_data: true,
     no_intra_emphasis: true,
-    renderer: UniqueHeadCounter
+    renderer: NestingUniqueHeadCounter
 
 # Assets
 set :css_dir, 'stylesheets'

--- a/source/includes/_errors.md.erb
+++ b/source/includes/_errors.md.erb
@@ -20,14 +20,14 @@ of errors.
 
 
 
-### HTTP Status Codes
+## HTTP Status Codes
 
 Code | Meaning
 ---- | -------
 `200` OK | All is well.
 `201` Created | Your request has been fulfilled and has resulted in one or more new resources being created.
 `204` No Content | Your request has been fulfilled and that there is no additional content to send in the response payload body. e.g deleting a resource.
-`401` Unauthorized | Your request is not authenticated. See the [Authentication Errors](#authentication-errors) section for more information.
+`401` Unauthorized | Your request is not authenticated. See the [Authentication Errors](#errors-authentication-errors) section for more information.
 `404` Page Not Found | The endpoint requested does not exist.
 `422` Unprocessable Entity | The resource couldn't be created or updated due to a validation error. Please see the response body for more information.
 `429` Too Many Requests | Your application is exceeding its rate limit. Slow down, pal!
@@ -35,7 +35,7 @@ Code | Meaning
 `504` Gateway Timeout|Something has timed out on our end.
 
 
-### Authentication Errors
+## Authentication Errors
 
 ```json
 {

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -52,4 +52,4 @@ Developers can find their API token by signing in at [https://id.tito.io](https:
 
 Your API token needs to included in the `Authorization` header so your requests can be authenticated.
 
-The Tito API also provides detailed information about [Authentication Errors](#authentication-errors).
+The Tito API also provides detailed information about [Authentication Errors](#errors-authentication-errors).


### PR DESCRIPTION
### Story

As an API developer, when I click the attributes link in the Release nav I should be taken to the Releases attributes not the Activities attributes.

### Details 

This is due to the same anchor being generated for each endpoint resources.

https://github.com/lord/slate/wiki/Using-the-same-link-for-several-menu-items