### PR TITLE
Add the missing refund response after re-adding the refund `show` act…

### DIFF
--- a/source/includes/_refunds.md.erb
+++ b/source/includes/_refunds.md.erb
@@ -37,7 +37,3 @@ Retrieves a `Refund` for the given `Event`.
 * `account_slug` - The `slug` attribute of an `Account`.
 * `event_slug` - The `slug` attribute of an `Event`.
 * `refund_id` - The `id` attribute of a `Refund`.
-
-<aside class="warning">
-FIXME: THIS IS MISSING FROM DASHBOARD
-</aside>

--- a/source/includes/refunds/_show.json.md
+++ b/source/includes/refunds/_show.json.md
@@ -1,3 +1,14 @@
 ```json
-{}
+{
+  "refund":{
+    "_type": "refund",
+    "id": 123456,
+    "amount": "100.0",
+    "created_at": "2018-02-09T13:14:26.000+00:00",
+    "manual": null,
+    "registration":{
+      ...
+    }
+  }
+}
 ```


### PR DESCRIPTION
### Story

As an API developer, I should be able to retrieve a specific refund from the API

### Details 

The original action to retrieve a specific refund by it's id doesn't exist. We need to reintroduce it.

### PR

https://github.com/teamtito/dashboard-tito/pull/211
