### PR TITLE
Reassign a ticket

### DIFF
--- a/data/reassignments.json
+++ b/data/reassignments.json
@@ -1,0 +1,22 @@
+{
+  "attributes": {
+    "email": {
+      "description": "The email of the attendee.",
+      "type": "string",
+      "read_only": false,
+      "required": true
+    },
+    "first_name": {
+      "description": "The first name of the attendee.",
+      "type": "string",
+      "read_only": false,
+      "required": false
+    },
+    "last_name": {
+      "description": "The last name of the attendee.",
+      "type": "string",
+      "read_only": false,
+      "required": false
+    }
+  }
+}

--- a/data/reassignments.json
+++ b/data/reassignments.json
@@ -17,6 +17,12 @@
       "type": "string",
       "read_only": false,
       "required": false
+    },
+    "delete_answers": {
+      "description": "Whether to delete the answers made by the original attendee. Defaults to false.",
+      "type": "boolean",
+      "read_only": false,
+      "required": false
     }
   }
 }

--- a/source/includes/_tickets.md.erb
+++ b/source/includes/_tickets.md.erb
@@ -90,3 +90,39 @@ Update a `Ticket` belonging to the given `Event`.
 ### Parameters
 
 <%= partial "includes/shared/parameters", locals: { parameters: data.tickets.attributes.reject { |name,attribute| attribute["read_only"] } } %>
+
+## Reassign a Ticket
+
+<%= partial "includes/requests/post",
+  locals: {
+    url: "#{config[:api_endpoint]}/:account_slug/:event_slug/tickets/:ticket_slug/reassignments",
+    parameters: {
+      reassignment: {
+        email: "jane@example.com",
+        first_name: "Jane",
+        last_name: "Smith"
+      }
+    }
+  }
+%>
+<%= partial "includes/reassignments/create.json" %>
+
+Reassign a `Ticket` to a new attendee.
+
+`POST <%= "#{config[:api_endpoint]}/:account_slug/:event_slug/tickets/:ticket_slug/reassignments" %>`
+
+* `account_slug` - The `slug` attribute of an `Account`.
+* `event_slug` - The `slug` attribute of an `Event`.
+* `ticket_slug` - The `slug` attribute of a `Ticket`.
+
+### Parameters
+
+<%= partial "includes/shared/parameters", locals: { parameters: data.reassignments.attributes.reject { |name,attribute| attribute["read_only"] } } %>
+
+### Emails Sent
+
+The following people receive an email after a reassignment:
+
+* the new attendee
+* the orderer (if their email is different to the original email for this ticket)
+* the organisers (if they have chosen to receive notifications)

--- a/source/includes/_tickets.md.erb
+++ b/source/includes/_tickets.md.erb
@@ -100,14 +100,15 @@ Update a `Ticket` belonging to the given `Event`.
       reassignment: {
         email: "jane@example.com",
         first_name: "Jane",
-        last_name: "Smith"
+        last_name: "Smith",
+        delete_answers: true
       }
     }
   }
 %>
 <%= partial "includes/reassignments/create.json" %>
 
-Reassign a `Ticket` to a new attendee.
+Reassign a `Ticket` to a new attendee. It's different from just updating the email and name for a ticket: reassigning a ticket also sends out an email to the new attendee and (optionally) deletes all the answers made by the original attendee.
 
 `POST <%= "#{config[:api_endpoint]}/:account_slug/:event_slug/tickets/:ticket_slug/reassignments" %>`
 

--- a/source/includes/reassignments/_create.json.md
+++ b/source/includes/reassignments/_create.json.md
@@ -1,12 +1,46 @@
 ```json
 {
-  "ticket/reassignment": {
-    "_type": "ticket/reassignment",
-    "email": "jane@example.com",
+  "ticket": {
+    "_type": "ticket",
+    "id": 3068932,
+    "slug": "ti_dPkq1HwyzQjJdF1dvhHjzEg",
+    "company_name": null,
+    "email": null,
+    "metadata": null,
     "first_name": "Jane",
-    "last_name": "Smith",
-    "reference": "ZBRE-1",
-    "slug": "ti_dhlR2CSzh59ZLht5ELPkxjg"
+    "last_name": "Doe",
+    "name": "Jane Doe",
+    "number": null,
+    "phone_number": null,
+    "price": "0.0",
+    "reference": "PNGU-1",
+    "state": "complete",
+    "test_mode": true,
+    "registration_id": 3509398,
+    "release_id": 1105525,
+    "consented_at": null,
+    "discount_code_used": null,
+    "created_at": "2018-11-12T13:54:00.000+00:00",
+    "updated_at": "2018-11-12T13:54:00.000+00:00",
+    "responses": null,
+    "assigned": false,
+    "price_less_tax": "0.0",
+    "total_paid": "0.0",
+    "total_tax_paid": "0.0",
+    "total_paid_less_tax": "0.0",
+    "tags": null,
+    "upgrade_ids": [],
+    "upgrade_summary": {},
+    "registration_slug": "reg_test_dp729LA0bGxEFfgeyldOVuA",
+    "release_slug": "coffee-brewing",
+    "release_title": "Coffee Brewing",
+    "registration": {
+      ...
+    },
+    "release": {
+      ...
+    },
+    "answers": []
   }
 }
 ```

--- a/source/includes/reassignments/_create.json.md
+++ b/source/includes/reassignments/_create.json.md
@@ -1,0 +1,12 @@
+```json
+{
+  "ticket/reassignment": {
+    "_type": "ticket/reassignment",
+    "email": "jane@example.com",
+    "first_name": "Jane",
+    "last_name": "Smith",
+    "reference": "ZBRE-1",
+    "slug": "ti_dhlR2CSzh59ZLht5ELPkxjg"
+  }
+}
+```


### PR DESCRIPTION
This is a new endpoint so that organisers can reassign tickets. It differs from just updating the email and name in that it also sends an email to the new attendee. See: [Dashboard PR 215](https://github.com/teamtito/dashboard-tito/pull/215)