### PR TITLE
Remove the v3 from the build path.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 namespace :assets do
   task :precompile do
     sh "middleman build --build-dir='build/docs/api/v3'"
+    sh "middleman build --build-dir='build/docs/api' --no-clean"
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -25,6 +25,6 @@ run lambda { |env|
       "Content-Type" => "text/html",
       "Cache-Control" => "public, max-age=60"
     },
-    File.open("build/docs/api/v3/404.html", File::RDONLY)
+    File.open("build/docs/api/404.html", File::RDONLY)
   ]
 }


### PR DESCRIPTION
Build the site twice once in `/docs/api/v3/` and another in `/docs/api/`. This is so that we can remove the `/v3` part from the url and make the necessary load balancer changes without docs disappearing on people. Once we have made the load balancer changes we can reduce this to one build.

See infra changes here to support this and deployment strategy : https://github.com/teamtito/tito-opsworks/pull/19
