### PR TITLE
Add past event docs

### DIFF
--- a/source/docs/api/changelog/index.html.md.erb
+++ b/source/docs/api/changelog/index.html.md.erb
@@ -6,6 +6,11 @@ layout: "full_width"
 
 # Change Log
 
+## 11th Dec 2018
+
+### Added
+
+* Added endpoint to retrieve past events.
 
 ## 4th Dec 2018
 

--- a/source/includes/admin_api/_events.md.erb
+++ b/source/includes/admin_api/_events.md.erb
@@ -35,6 +35,20 @@ Retrieves all upcoming `Events` for the given `Account`.
 
 * `account_slug` - The `slug` attribute of an `Account`.
 
+## Get all past Events
+
+<%= partial "includes/requests/get",
+  locals: {
+    url: "#{config[:api_endpoint]}/:account_slug/events/past"
+  }
+%>
+
+Retrieves all past `Events` for the given `Account`.
+
+`<%= "GET #{config[:api_endpoint]}/:account_slug/events/past" %>`
+
+* `account_slug` - The `slug` attribute of an `Account`.
+
 
 ## Get an Event
 


### PR DESCRIPTION
### Story

As an API developer who is interested in their past events, I want the ability to fetch information about them so I can build third party apps