### PR TITLE
Make sure we document all the plugins

### DIFF
--- a/source/docs/api/index.html.md.erb
+++ b/source/docs/api/index.html.md.erb
@@ -10,6 +10,8 @@ search: false
 
 # Welcome
 
+## API
+
 The Tito API is divided into the following components:
 
 The **<a href='/docs/api/admin/'>Admin API</a>** is the API that powers our admin dashboard.
@@ -19,3 +21,7 @@ The **<a href='/docs/api/checkout/'>Checkout API</a> (coming 2021)** is what pow
 The **<a href='/docs/api/checkin/'>Check-in API</a>** powers our mobile and web-based check-in apps.
 
 Using any combination of the three APIs, you can leverage and build on the entire feature-set of Tito in your own apps.
+
+## Widget
+
+The **<a href='/docs/api/widget/'>Widget</a>** allows you to embed Tito into your own website.

--- a/source/docs/api/widget/index.html.md.erb
+++ b/source/docs/api/widget/index.html.md.erb
@@ -377,24 +377,41 @@ Note that the `?prefill=` bit comes **after** the `/#/` bit.
 ## Plugins
 
 ```html
-<script src='https://js.tito.io/v2/with/gtm' async></script>
+<script
+  src='https://js.tito.io/v2/with/plugin1,plugin2'
+  async
+  ></script>
 ```
 
-Various plugins are available that have pre-defined integrations with third-party tools. To load plugins, you can append `with/<pluginname>` to the end of the `src` attribute of the `script` tag.
-
-### Google Tag Manager
-
-The `gtm` plugin sends data to a `dataLayer` for use with Google Tag Manager. To use this plugin, the following must be set up:
-
-1. Google Tag Manager should already be loaded on the page you're embedding the widget
-2. Enhanced eCommerce must be set up on your tag
-3. You can track the folowing events:
-  - tito:checkout
-  - tito:purchase
+Various plugins are available that have pre-defined integrations with third-party tools. To load plugins, you can append `with/<pluginname>` to the end of the `src` attribute of the `script` tag. You can use multiple plugins by separating them with a comma.
 
 ### Facebook
 
 The `facebook` plugin sends data via Facebook's `fbq` function. Make sure that you have loaded the facebook `script` to use this plugin.
+
+### Inline
+
+By default, the widget is loaded inside an iframe. This makes it easy to isolate the CSS and make sure your website's design doesn't leak into the widget. However, if you want full control over how the widget looks then using the `inline` plugin will skip the iframe and embed it directly into your website. You can then use your own CSS to style the widget.
+
+Using the widget inline also allows you to listen to any of the javascript [callbacks](#tito-widget-v2-callbacks).
+
+### Google Analytics
+
+We have three different plugins for Google Analytics:
+
+* `ga`
+* `gtag`
+* `gtm`
+
+Read more about which one to use and how to integrate it into your website [here](https://help.tito.io/en/articles/2006249-google-analytics).
+
+### Hits
+
+Use the `hits` plugin to record a page view every time someone loads the widget.
+
+### Trialfire
+
+Use the `trialfire` plugin to integrate with [Trialfire](https://trialfire.com/).
 
 ## Test Mode
 

--- a/source/docs/api/widget/index.html.md.erb
+++ b/source/docs/api/widget/index.html.md.erb
@@ -399,7 +399,7 @@ Using the widget inline also allows you to listen to any of the javascript [call
 
 We have three different plugins for Google Analytics:
 
-* `ga`
+* `google_analytics`
 * `gtag`
 * `gtm`
 

--- a/source/includes/shared/_nav.md.erb
+++ b/source/includes/shared/_nav.md.erb
@@ -3,4 +3,5 @@
   <li><a href="/docs/api/checkout">Checkout API</a> <span>Coming 2021</span></li>
   <li><a href="/docs/api/checkin">Check-in API</a></li>
   <li><a href="/docs/api/changelog">Changelog</a></li>
+  <li><a href="/docs/api/widget">Widget</a></li>
 </ul>


### PR DESCRIPTION
> As an organiser, I want to know how to use all the plugins.

<img width="1030" alt="CleanShot 2021-06-10 at 11 31 07@2x" src="https://user-images.githubusercontent.com/19054/121510784-e9a92b00-c9df-11eb-8504-ce0d41e7d6c5.png">

# Intercom Help Docs

The [Google Analytics article on Intercom](https://app.intercom.com/a/apps/nhi52s19/articles/articles/2006249/show) needs bringing up to date as well.

- [x] ~I think the `google_analytics` plugin mentioned should be `ga`?~ `ga` is obsolete
- [x] Should we add information there about tracking the `tito:checkout` and `tito:purchase` events?