### PR TITLE
Mention the new `ga4` plugin

### DIFF
--- a/source/docs/api/widget/index.html.md.erb
+++ b/source/docs/api/widget/index.html.md.erb
@@ -403,7 +403,9 @@ Using the widget inline also allows you to listen to any of the javascript [call
 
 ### Google Analytics
 
-We have three different plugins for Google Analytics:
+Google Analytics is changing. Their eCommerce tracking is moving to `GA4`, and as such, we are trialling a new `ga4` plugin.
+
+The below plugins are now deprecated:
 
 * `google_analytics`
 * `gtag`


### PR DESCRIPTION
PR for an update to the docs mentioning the `ga4` plugin and deprecating the existing ones.