### PR TITLE
Webhook payload API docs mentions a Rails specific class name in the payload json 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.2]
+        ruby-version: [3.2.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby "3.2"
+ruby "3.2.0"
 source "https://rubygems.org"
 
 # Middleman

--- a/data/3.0/tickets/webhook_payload.json
+++ b/data/3.0/tickets/webhook_payload.json
@@ -56,7 +56,9 @@
     "where-do-you-live": "United States"
   },
   "last_updated_by_type": "admin",
-  "upgrades": "#<Upgrade::ActiveRecord_Associations_CollectionProxy:0x0000aaaaeefacf50>",
+  "upgrades": [
+
+  ],
   "upgrade_ids": [
 
   ],

--- a/data/3.1/tickets/webhook_payload.json
+++ b/data/3.1/tickets/webhook_payload.json
@@ -56,7 +56,9 @@
     "where-do-you-live": "United States"
   },
   "last_updated_by_type": "admin",
-  "upgrades": "#<Upgrade::ActiveRecord_Associations_CollectionProxy:0x0000aaaaf4a51078>",
+  "upgrades": [
+
+  ],
   "upgrade_ids": [
 
   ],

--- a/source/docs/api/changelog/index.html.md.erb
+++ b/source/docs/api/changelog/index.html.md.erb
@@ -13,25 +13,25 @@ layout: "changelog"
 
 ## 4 Jan 2024
 
-* Add :show_public_releases, :show_secret_releases, :block_registrations_if_not_applicable attributes to discount codes API v3.1.
+* Add `:show_public_releases`, `:show_secret_releases`, `:block_registrations_if_not_applicable` attributes to discount codes API v3.1.
 
 ## 28 Sept 2023
 
-* The :reminder ticket :state is dropped in the v3 Admin API.
+* The `:reminder` ticket `:state` is dropped in the v3 Admin API.
 
 ## 29 May 2023
 
-* Add sections for new <tito-register-interest> and <tito-events> widgets.
+* Add sections for new `<tito-register-interest>` and `<tito-events>` widgets.
 
 ## 18 April 2023
 
-* Add development_mode plugin to widget docs.
+* Add `development_mode` plugin to widget docs.
 
 ## 14 Jul 2023
 
 * Enable [test mode with a plugin](docs/api/widget#tito-widget-v2-plugins) instead of a API key.
 
-# 8 Feb 2023
+## 8 Feb 2023
 
 * Add docs about the [ga4 plugin](docs/api/widget#tito-widget-v2-plugins) 
 

--- a/source/docs/api/changelog/index.html.md.erb
+++ b/source/docs/api/changelog/index.html.md.erb
@@ -7,6 +7,38 @@ layout: "changelog"
 
 # Changelog
 
+## 16 April 2024
+
+* Fix incorrect JSON in the webhook payloads example.
+
+## 4 Jan 2024
+
+* Add :show_public_releases, :show_secret_releases, :block_registrations_if_not_applicable attributes to discount codes API v3.1.
+
+## 28 Sept 2023
+
+* The :reminder ticket :state is dropped in the v3 Admin API.
+
+## 29 May 2023
+
+* Add sections for new <tito-register-interest> and <tito-events> widgets.
+
+## 18 April 2023
+
+* Add development_mode plugin to widget docs.
+
+## 14 Jul 2023
+
+* Enable [test mode with a plugin](docs/api/widget#tito-widget-v2-plugins) instead of a API key.
+
+# 8 Feb 2023
+
+* Add docs about the [ga4 plugin](docs/api/widget#tito-widget-v2-plugins) 
+
+## 14 Sept 2022
+
+* Add the waitlisted people API docs.
+
 ## 5 April 2022
 
 We've released [version 3.1 of our Admin API](/docs/api/admin/3.1) in beta.


### PR DESCRIPTION
### Issue

Webhook payload API docs mentions a Rails specific class name in the payload json

https://app.asana.com/0/0/1207063724224973

### Details

* Remove Rails specific class name in the webhook payload docs.
* Update the changelog including changes we've made since our last entry.
* Fix the ruby version in the github workflow. I don't believe we are using the github actions for anything?

