### PR TITLE
Remove the API early access banner from the API docs

### DIFF
--- a/source/docs/api/stylesheets/screen.css.scss
+++ b/source/docs/api/stylesheets/screen.css.scss
@@ -38,36 +38,6 @@ body {
   -webkit-text-size-adjust: none; /* Never autoresize text */
 }
 
-.api-warning {
-  align-items: center;
-  background: $link-blue;
-  color: #fff;
-  display: flex;
-  /* height: 60px; */
-  justify-content: center;
-  line-height: 1.4;
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  z-index: 99;
-  p {
-    margin: 0;
-    padding: 10px;
-    text-align: center;
-  }
-  a {
-    color: #fff;
-  }
-  @media (min-width: 365px) {
-    /* height: 40px; */
-  }
-  @media (min-width: 700px) {
-    /* height: 20px; */
-  }
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // TABLE OF CONTENTS
 ////////////////////////////////////////////////////////////////////////////////
@@ -81,12 +51,11 @@ body {
 
 .toc-wrapper {
   transition: left 0.3s ease-in-out;
-
   position: fixed;
   z-index: 30;
   top: 0;
   left: 0;
-  bottom: 40px;
+  bottom: 1px;
   width: $nav-width;
   background-color: $nav-bg;
   font-size: 13px;

--- a/source/includes/shared/_api_warning.md.erb
+++ b/source/includes/shared/_api_warning.md.erb
@@ -1,3 +1,0 @@
-<div class="api-warning">
-  <p><b>API Early Access</b> Please note this API is under active development &mdash; view our <a href="/docs/api/changelog/">Changelog</a>&nbsp;for&nbsp;updates</p>
-</div>

--- a/source/layouts/changelog.erb
+++ b/source/layouts/changelog.erb
@@ -41,7 +41,6 @@ under the License.
         <%= image_tag('navbar.png') %>
       </span>
     </a>
-    <%= partial "includes/shared/api_warning" %>
     <div class="toc-wrapper">
       <a class="logo" href="/docs/api">
         <%= image_tag "tito.svg" %> <%= current_page.data.api_name || "API Docs" %>

--- a/source/layouts/full_width.erb
+++ b/source/layouts/full_width.erb
@@ -51,7 +51,6 @@ under the License.
         <%= image_tag('navbar.png') %>
       </span>
     </a>
-    <%= partial "includes/shared/api_warning" %>
     <div class="toc-wrapper">
       <a class="logo" href="/docs/api">
         <%= image_tag "tito.svg" %> <%= current_page.data.api_name || "API Docs" %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -72,7 +72,6 @@ under the License.
         <%= image_tag('navbar.png') %>
       </span>
     </a>
-    <%= partial "includes/shared/api_warning" %>
     <div class="toc-wrapper">
       <a class="logo" href="/docs/api">
         <%= image_tag "tito.svg" %> <%= current_page.data.api_name || "API Docs" %>


### PR DESCRIPTION
### Story

Remove the API early access banner from the API docs as we've had the API for a while and the API is pretty stable now. Having it makes us look like we don't have an API.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207085409721378