### PR TITLE
Remove registration started webhook

### DIFF
--- a/data/webhooks.json
+++ b/data/webhooks.json
@@ -33,16 +33,8 @@
       "description": "Fired when a ticket is changed to a voided state. Free tickets that are cancelled by the attendee will also cause this webhook to fire."
     },
     {
-      "name": "registration.started",
-      "description": "Fired when a registration is started e.g. after they have selected tickets but before they have filled in any details."
-    },
-    {
       "name": "registration.updated",
       "description": "Fired when the registration is updated in the Tito admin area or via the API."
-    },
-    {
-      "name": "registration.filling",
-      "description": "Fired as soon as the person registering starts to filling in details like name, email, etc."
     },
     {
       "name": "registration.finished",

--- a/source/docs/api/changelog/index.html.md.erb
+++ b/source/docs/api/changelog/index.html.md.erb
@@ -7,7 +7,7 @@ layout: "changelog"
 
 # Changelog
 
-## 7 May 2024
+## 8 May 2024
 
 * Remove `registration.started` webhook.
 

--- a/source/docs/api/changelog/index.html.md.erb
+++ b/source/docs/api/changelog/index.html.md.erb
@@ -7,6 +7,10 @@ layout: "changelog"
 
 # Changelog
 
+## 7 May 2024
+
+* Remove `registration.started` webhook.
+
 ## 16 April 2024
 
 * Fix incorrect JSON in the webhook payloads example.


### PR DESCRIPTION
### Story

Remove the `registration.started` webhook as we havent been firing it since moving legacy over to dashboard.

There are also concerns about showing customer data before they have consented.

Asana - https://app.asana.com/0/0/1207183191084330

### Details

* Remove the `registration.started` from the API docs.
* Remove the `registration.filling` from the API docs as we haven't been firing that for a while.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207256249963896