### PR TITLE
PRO-633 Add documentation for refunding and cancelling a

### DIFF
--- a/lib/doc_builder.rb
+++ b/lib/doc_builder.rb
@@ -298,6 +298,22 @@ def list_attributes(attributes, skip: [], context: nil)
   concat "</ul>\n"
 end
 
+def list_simple_attributes(attributes)
+  concat "<ul class=\"attribute-list\">"
+  attributes.each do |name, hash|
+    concat "<li>"
+    concat "<div>"
+    concat "<code class=\"name\">#{name}</code>"
+    concat "<span class=\"type\">#{hash[:type]}</span>" if hash[:type].present?
+    concat "<span class=\"required\">required</span>" if hash[:required]
+    concat "</div>"
+    concat "<div class=\"attribute-description\">#{hash[:description].gsub(/`([^`]+)`/, '<code>\1</code>')}</div>" if hash[:description].present?
+    concat "</li>"
+  end
+  concat "</ul>"
+  nil
+end
+
 def list_attribute(name, hash, skip:, context:)
   concat "<li><div>"
   concat "<code class=\"name\">#{name}</code>"

--- a/source/includes/admin_api/3.1/_registrations.md.erb
+++ b/source/includes/admin_api/3.1/_registrations.md.erb
@@ -123,3 +123,19 @@ Changes the `receipt_paid` attribute to true.
 Show that a `Registration` has NOT been paid. Useful if you are allowing your customers to pay by invoice. You wouldn't normally need to do this but might do if you [marked it as paid](/docs/api/admin/#registrations-mark-a-registration-as-paid) by mistake.
 
 Changes the `receipt_paid` attribute to false.
+
+## Refund a Registration
+
+<%= show_url "registrations/:registration_slug/refunds", method: :post, params: { refund: { manual: false } }%>
+<%= show_url_key "POST registrations/:registration_slug/refunds" %>
+
+### Parameters
+
+<%= list_simple_attributes "refund[manual]": { type: :boolean, description: "Set to true if you don't want to refund via the payment provider or false if you do.", required: true } %>
+
+## Cancel a Registration
+
+<%= show_url "registrations/:registration_slug/cancellation", method: :post %>
+<%= show_url_key "POST registrations/:registration_slug/cancellation" %>
+
+This will cancel a registration and void any associated tickets.


### PR DESCRIPTION
See [Add documentation for refunding and cancelling a registration](https://linear.app/tito/issue/PRO-633/add-documentation-for-refunding-and-cancelling-a-registration) [Linear]

![CleanShot 2024-08-30 at 11 39 29](https://github.com/user-attachments/assets/82b14980-1ac0-49dd-ac18-c55563440858)

I fought with Slate for a while to get this done. I ended up writing a new method in `DocBuilder` that was simpler so I could create a list of parameters. There may be a better way of doing this but it's already taken me too long to get this far 🤯 