### PR TITLE
PRO-864 update the api docs

### DIFF
--- a/data/3.1/events/attributes.json
+++ b/data/3.1/events/attributes.json
@@ -530,8 +530,20 @@
     "translated": false,
     "type": null
   },
+  "end_at": {
+    "description": "The date and time the event is going to end based on the `end_date` and `end_time`, e.g. 2020-12-31T20:00:00.000+01:00.",
+    "expandable": false,
+    "expand_ids": false,
+    "expand_slugs": false,
+    "ignore": false,
+    "read_only": false,
+    "write_only": false,
+    "required": false,
+    "translated": false,
+    "type": "timestamp"
+  },
   "end_date": {
-    "description": "The date the event is going to end",
+    "description": "The date the event is going to end, e.g. 2020-12-31",
     "expandable": false,
     "expand_ids": false,
     "expand_slugs": false,
@@ -541,6 +553,18 @@
     "required": false,
     "translated": false,
     "type": "date"
+  },
+  "end_time": {
+    "description": "The time the event is going to end using the event's `timezone`, e.g. 18:00",
+    "expandable": false,
+    "expand_ids": false,
+    "expand_slugs": false,
+    "ignore": false,
+    "read_only": false,
+    "write_only": false,
+    "required": false,
+    "translated": false,
+    "type": "time"
   },
   "facebook_share_message": {
     "description": null,
@@ -1563,8 +1587,20 @@
     "translated": false,
     "type": "string"
   },
+  "start_at": {
+    "description": "The time the event is going to start based on the `start_date` and `start_time`, e.g. 2020-12-31T13:00:00.000+01:00",
+    "expandable": false,
+    "expand_ids": false,
+    "expand_slugs": false,
+    "ignore": false,
+    "read_only": false,
+    "write_only": false,
+    "required": false,
+    "translated": false,
+    "type": "timestamp"
+  },
   "start_date": {
-    "description": "The date the event is going to start",
+    "description": "The date the event is going to start, e.g. 2020-12-31",
     "expandable": false,
     "expand_ids": false,
     "expand_slugs": false,
@@ -1574,6 +1610,18 @@
     "required": false,
     "translated": false,
     "type": "date"
+  },
+  "start_time": {
+    "description": "The time the event is going to start using the event's time zone, e.g. 13:00",
+    "expandable": false,
+    "expand_ids": false,
+    "expand_slugs": false,
+    "ignore": false,
+    "read_only": false,
+    "write_only": false,
+    "required": false,
+    "translated": false,
+    "type": "time"
   },
   "stripe": {
     "description": null,

--- a/data/events.json
+++ b/data/events.json
@@ -91,19 +91,49 @@
       "required": false
     },
     "start_date": {
-      "description": "The date the event is going to start",
+      "description": "The date the event is going to start, e.g. 2020-12-31",
       "type": "date",
       "read_only": false,
       "required": false
     },
+    "start_time": {
+      "description": "The time the event is going to start using the event's time zone, e.g. 13:00",
+      "type": "string",
+      "read_only": false,
+      "required": false
+    },
+    "start_at": {
+      "description": "The time the event is going to start based on the `start_date` and `start_time`, e.g. 2020-12-31T13:00:00.000+01:00",
+      "type": "timestamp",
+      "read_only": false,
+      "required": false
+    },
     "end_date": {
-      "description": "The date the event is going to end",
+      "description": "The date the event is going to end, e.g. 2020-12-31",
       "type": "date",
+      "read_only": false,
+      "required": false
+    },
+    "end_time": {
+      "description": "The time the event is going to end using the event's `timezone`, e.g. 18:00",
+      "type": "string",
+      "read_only": false,
+      "required": false
+    },
+    "end_at": {
+      "description": "The time the event is going to end based on the `end_date` and `end_time`, e.g. 2020-12-31T18:00:00.000+01:00",
+      "type": "timestamp",
       "read_only": false,
       "required": false
     },
     "date_or_range": {
       "description": null,
+      "type": "string",
+      "read_only": true,
+      "required": false
+    },
+    "timezone": {
+      "description": "The time zone for the event, e.g. Paris",
       "type": "string",
       "read_only": true,
       "required": false


### PR DESCRIPTION
As a follow up to [this dashboard PR](https://github.com/teamtito/dashboard-tito/pull/2170), to update the API docs. The docs aren't as easy to update as I'd hoped. I'm sure it worked at some point. I did spend some time trying to get it automatically updating based on the `write_docs` Rake task in Dashboard (as described in the readme) but it didn't work. Sigh. 