### PR TITLE
Document custom placeholders for the register interest widget and make register interest/events widgets top level nav items.

### DIFF
--- a/source/docs/api/widget/index.html.md.erb
+++ b/source/docs/api/widget/index.html.md.erb
@@ -486,7 +486,7 @@ Use the `trialfire` plugin to integrate with [Trialfire](https://trialfire.com/)
 
 You can use `email-placeholder` and `name-placeholder` attributes to set custom placeholders for the name and email fields on the order form.
 
-## Events widget
+# Events widget
 
 To display a list of your upcoming and past events on your site, like what appears on your Tito public account timeline <a href="https://ti.to/events" target="_blank">here</a> for example, you can use the `<tito-events>` widget.
 
@@ -494,13 +494,25 @@ To display a list of your upcoming and past events on your site, like what appea
 <tito-events account="ultimateconf"></tito-events>
 ```
 
-## Register interest widget
-
-To add a form on your site for people to <a href="https://help.tito.io/en/articles/2003003-interested-people" target="_blank">register interest</a> in your event, you can use the `<tito-register-interest>` widget.
+# Register interest widget
 
 ```html
 <tito-register-interest event="ultimateconf/2013"></tito-register-interest>
 ```
+
+To add a form on your site for people to <a href="https://help.tito.io/en/articles/2003003-interested-people" target="_blank">register interest</a> in your event, you can use the `<tito-register-interest>` widget.
+
+## Custom placeholders
+
+```html
+<tito-register-interest
+  event="ultimateconf/2013"
+  email-placeholder="michael.scott@dundermifflin.inc"
+  name-placeholder="Michael Scott"
+  ></tito-register-interest>
+```
+
+You can use `email-placeholder` and `name-placeholder` attributes to set custom placeholders for the name and email fields on the register interest widget.
 
 <br>
 <br>


### PR DESCRIPTION
* Document custom placeholders for the register interest widget.
* Make register interest/events widgets top level nav items.

**Before**

![register-interest-widget-docs-before](https://github.com/user-attachments/assets/9a938198-f8e6-4ca7-a8d4-6818fbc5e67c)

**After**

![register-interest-widget-docs-after](https://github.com/user-attachments/assets/aa2bae53-5836-4f12-8d15-121f4e4c974b)
