### PR TITLE
PRO-1002 Show the banner as read-only

### DIFF
--- a/data/3.0/events/attributes.json
+++ b/data/3.0/events/attributes.json
@@ -125,7 +125,7 @@
     "expand_ids": false,
     "expand_slugs": false,
     "ignore": false,
-    "read_only": false,
+    "read_only": true,
     "write_only": false,
     "required": false,
     "translated": false,

--- a/data/3.1/events/attributes.json
+++ b/data/3.1/events/attributes.json
@@ -113,7 +113,7 @@
     "expand_ids": false,
     "expand_slugs": false,
     "ignore": false,
-    "read_only": false,
+    "read_only": true,
     "write_only": false,
     "required": false,
     "translated": false,

--- a/data/events.json
+++ b/data/events.json
@@ -15,7 +15,7 @@
     "banner": {
       "description": null,
       "type": "object",
-      "read_only": false,
+      "read_only": true,
       "required": false
     },
     "banner_url": {


### PR DESCRIPTION
[PRO-1002 Update Admin API docs to remove the section around uploading a banner](https://linear.app/tito/issue/PRO-1002/update-admin-api-docs-to-remove-the-section-around-uploading-a-banner)

See also [PR 2258](https://github.com/teamtito/dashboard-tito/pull/2258) in `dashboard-tito`.

I've manually updated the `read_only` attribute for `banner`.

![CleanShot 2025-01-08 at 09 46 43](https://github.com/user-attachments/assets/768c89a9-dc09-4826-9d24-132bd7c8fbe2)
