### PR TITLE
Bump mini_portile2 to unblock Heroku deploys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     middleman-syntax (3.3.0)
       middleman-core (>= 3.2)
       rouge (~> 3.2)
-    mini_portile2 (2.8.1)
+    mini_portile2 (2.8.9)
     minitest (5.17.0)
     nio4r (2.5.8)
     nokogiri (1.14.0)


### PR DESCRIPTION
For: https://linear.app/tito/issue/PRO-3670/cannot-deploy-classic-api-docs-due-to-could-not-find-mini-portile2-281

## Summary
- `mini_portile2 2.8.1` was yanked from rubygems.org, so `bundle install` on Heroku fails with `Could not find mini_portile2-2.8.1 in any of the sources` and the build aborts before any app code runs.
- Bumps the pin in `Gemfile.lock` from `2.8.1` → `2.8.9` (current latest in the 2.8.x line, compatible with `nokogiri ~> 1.14.0`).
- No application code changes; this is purely a one-line lockfile update to restore deploys.

## Test plan
- [ ] Merge and confirm Heroku build completes past the "Detecting dependencies" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)