### PR TITLE
Bump Bundler from 2.2.22 to 2.4.22 to unblock Heroku deploys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,4 +150,4 @@ RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.2.22
+   2.4.22


### PR DESCRIPTION
## Summary
- PR #93 didn't fix the Heroku deploy issue — the build still fails with `Could not find mini_portile2-2.8.9 in any of the sources`, even though that gem is published on rubygems.org and downloadable.
- The original build log's `DidYouMean::SPELL_CHECKERS.merge!` deprecation warning was the real clue: it's emitted by Bundler 2.2.x running on Ruby 3.2, a combination known to mis-report gem resolution errors against the current rubygems index.
- Bumps `BUNDLED WITH` from `2.2.22` (2021) to `2.4.22` — a stable Bundler that's compatible with Ruby 3.2. Heroku's Ruby buildpack will install that version on the next build.
- One-line lockfile change; no application code touched.

## Follow-up step (post-merge)
After this is merged, purge the Heroku build cache so the next deploy doesn't reuse stale state from the failing builds:
```
heroku builds:cache:purge -a <app-name>
```

## Test plan
- [ ] Merge, purge Heroku build cache, deploy, and confirm the build proceeds past the "Detecting dependencies" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)